### PR TITLE
Added alias support for flavors and renamed default templates to a simpler format

### DIFF
--- a/example-configs/debian.conf
+++ b/example-configs/debian.conf
@@ -19,32 +19,34 @@ RELEASE := 3
 
 # GIT_PREFIX - Git release repo prefix
 # Default: R2: qubes-r2/  R3: qubes-r3/
-GIT_PREFIX := marmarek/qubes-
+GIT_PREFIX := QubesOS/qubes-
 
 # DISTS_VM - Choose the templates to build.  Multiple templates can be defined 
 # to build.  Uncomment tempalte dist to build.
 # Default: fc20
 DISTS_VM := 
 #DISTS_VM += wheezy
-#DISTS_VM += wheezy+flash
+#DISTS_VM += wheezy+minimal
 #DISTS_VM += wheezy+gnome
-#DISTS_VM += wheezy+gnome+flash
 #DISTS_VM += jessie
-#DISTS_VM += jessie+flash
+#DISTS_VM += jessie+minimal
 DISTS_VM += jessie+gnome
-#DISTS_VM += jessie+gnome+flash
 #DISTS_VM += trusty
-#DISTS_VM += trusty+flash
 #DISTS_VM += trusty+desktop
-#DISTS_VM += trusty+desktop+flash
 #DISTS_VM += utopic
-#DISTS_VM += utopic+flash
 #DISTS_VM += utopic+desktop
-#DISTS_VM += utopic+desktop+flash
 #DISTS_VM += vivid
-#DISTS_VM += vivid+flash
 #DISTS_VM += vivid+desktop
-#DISTS_VM += vivid+desktop+flash
+#DISTS_VM += whonix-gateway
+#DISTS_VM += whonix-gateway+minimal
+#DISTS_VM += whonix-workstation
+#DISTS_VM += whonix-workstation+gnome
+#DISTS_VM += fc20
+#DISTS_VM += fc20+minimal
+#DISTS_VM += fc20+fullyloaded
+#DISTS_VM += fc21
+#DISTS_VM += fc21+minimal
+#DISTS_VM += fc21+fullyloaded
 
 # DEBUG - Print verbose messages about qubes-builder itself - set "1" to use it
 # Default: no value

--- a/example-configs/extended-rules.conf
+++ b/example-configs/extended-rules.conf
@@ -9,10 +9,11 @@ ifdef DISTS_DEFINED
   alias_name = $(word 1,$(subst :, ,$(ALIAS)))
   alias_flavor = $(word 2,$(subst :, ,$(ALIAS)))
   template_name = $(subst +,-,$(alias_name))
-  aliases = $(filter $(alias_flavor), $(patsubst $(alias_name), $(alias_flavor), $(DISTS_VM))) \
-                     $(if $(filter $(alias_flavor):$(template_name), $(TEMPLATE_LABEL)),, \
-                         $(eval TEMPLATE_LABEL += $(alias_flavor):$(template_name)))
-  DISTS_VM := $(strip $(foreach ALIAS, $(TEMPLATE_ALIAS), $(aliases)))
+  aliases = $(eval DISTS_VM := $(patsubst $(alias_name), $(alias_flavor), $(DISTS_VM))) \
+            $(if $(filter $(alias_flavor):$(template_name), $(TEMPLATE_LABEL)),, \
+                $(eval TEMPLATE_LABEL += $(alias_flavor):$(template_name)) \
+            )
+  $(strip $(foreach ALIAS, $(TEMPLATE_ALIAS), $(aliases)))
 endif
 
 # Remove any unused labels

--- a/example-configs/extended-rules.conf
+++ b/example-configs/extended-rules.conf
@@ -4,6 +4,25 @@
 #             E X T R A   M A K E F I L E   T A R G E T S
 ################################################################################
 
+# Apply aliases and add TEMPLATE_LABEL if it does not already exist
+ifdef DISTS_DEFINED
+  alias_name = $(word 1,$(subst :, ,$(ALIAS)))
+  alias_flavor = $(word 2,$(subst :, ,$(ALIAS)))
+  template_name = $(subst +,-,$(alias_name))
+  aliases = $(filter $(alias_flavor), $(patsubst $(alias_name), $(alias_flavor), $(DISTS_VM))) \
+                     $(if $(filter $(alias_flavor):$(template_name), $(TEMPLATE_LABEL)),, \
+                         $(eval TEMPLATE_LABEL += $(alias_flavor):$(template_name)))
+  DISTS_VM := $(strip $(foreach ALIAS, $(TEMPLATE_ALIAS), $(aliases)))
+endif
+
+# Remove any unused labels
+ifdef DISTS_DEFINED
+  template_flavor = $(word 1,$(subst :, ,$(LABEL)))
+  template_name = $(word 2,$(subst :, ,$(LABEL)))
+  labels = $(filter $(filter $(template_flavor), $(DISTS_VM)):$(template_name), $(LABEL))
+  TEMPLATE_LABEL := $(strip $(foreach LABEL, $(TEMPLATE_LABEL), $(labels)))
+endif
+
 # Get rid of quotes
 TEMPLATE_FLAVOR := $(shell echo $(TEMPLATE_FLAVOR))
 WHONIX_DIR := $(shell echo $(WHONIX_DIR))
@@ -78,6 +97,7 @@ build-info::
 	@echo "TEMPLATE        = $(TEMPLATE)"
 	@echo "GIT_REPOS       = $(GIT_REPOS)"
 	@echo "COMPONENTS      = $(COMPONENTS)"
+	@echo "TEMPLATE_LABEL  = $(TEMPLATE_LABEL)"
 	@echo
 
 .PHONY: get-sources
@@ -97,6 +117,7 @@ qubes-vm::
 	@true
 
 .PHONY: template
+
 template linux-template-builder:: umount build-info
 	@echo "Creating template(s)..."
 

--- a/example-configs/templates.conf
+++ b/example-configs/templates.conf
@@ -131,30 +131,21 @@ DIST_DOM0 ?= fc20
 ifndef DISTS_DEFINED
   DISTS_VM := 
   DISTS_VM += wheezy
-  DISTS_VM += wheezy+flash
+  DISTS_VM += wheezy+minimal
   DISTS_VM += wheezy+gnome
-  DISTS_VM += wheezy+gnome+flash
   DISTS_VM += jessie
-  DISTS_VM += jessie+flash
+  DISTS_VM += jessie+minimal
   DISTS_VM += jessie+gnome
-  DISTS_VM += jessie+gnome+flash
   DISTS_VM += trusty
-  DISTS_VM += trusty+flash
   DISTS_VM += trusty+desktop
-  DISTS_VM += trusty+desktop+flash
   DISTS_VM += utopic
-  DISTS_VM += utopic+flash
   DISTS_VM += utopic+desktop
-  DISTS_VM += utopic+desktop+flash
   DISTS_VM += vivid
-  DISTS_VM += vivid+flash
   DISTS_VM += vivid+desktop
-  DISTS_VM += vivid+desktop+flash
-  DISTS_VM += wheezy+whonix-gateway
-  DISTS_VM += wheezy+whonix-workstation
-  DISTS_VM += wheezy+whonix-workstation+flash
-  DISTS_VM += wheezy+whonix-workstation+gnome
-  DISTS_VM += wheezy+whonix-workstation+gnome+flash
+  DISTS_VM += whonix-gateway
+  DISTS_VM += whonix-gateway+minimal
+  DISTS_VM += whonix-workstation
+  DISTS_VM += whonix-workstation+gnome
   DISTS_VM += fc20
   DISTS_VM += fc20+minimal
   DISTS_VM += fc20+fullyloaded
@@ -164,6 +155,27 @@ ifndef DISTS_DEFINED
 endif
 
 ################################################################################
+#                     T E M P L A T E   A L I A S 
+################################################################################
+# TEMPLATE_ALIAS can be used to choose a shorter name in DISTS_VM that
+# include some other TEMPLATE_FLAVORs.  A TEMPLATE_LABEL will automatically
+# be created if one does not exist that will use the alias name as the 
+# tempalte name.  Plus signs (+) will be converted to hyphens (-).
+TEMPLATE_ALIAS ?=
+TEMPLATE_ALIAS += wheezy:wheezy+standard
+TEMPLATE_ALIAS += wheezy+gnome:wheezy+gnome+standard
+TEMPLATE_ALIAS += wheezy+minimal:wheezy+minimal+no-recommends
+
+TEMPLATE_ALIAS += jessie:jessie+standard
+TEMPLATE_ALIAS += jessie+gnome:jessie+gnome+standard
+TEMPLATE_ALIAS += jessie+minimal:jessie+minimal+no-recommends
+
+TEMPLATE_ALIAS += whonix-gateway:wheezy+whonix-gateway+standard
+TEMPLATE_ALIAS += whonix-gateway+minimal:wheezy+whonix-gateway+minimal
+TEMPLATE_ALIAS += whonix-workstation:wheezy+whonix-workstation+standard
+TEMPLATE_ALIAS += whonix-workstation+gnome:wheezy+whonix-workstation+gnome+standard
+
+################################################################################
 #                 T E M P L A T E   C O N F I G U R A T I O N
 ################################################################################
 # TEMPLATE_LABEL allows control over the final template name.  There is a limit
@@ -171,31 +183,10 @@ endif
 # 
 # TEMPLATE_LABE += <DIST_VM name as listed above>:<desired final template name>
 TEMPLATE_LABEL ?=
-TEMPLATE_LABEL += wheezy:debian-7-x64
-TEMPLATE_LABEL += wheezy+flash:debian-7-x64
-TEMPLATE_LABEL += wheezy+gnome:debian-7-x64-gnome
-TEMPLATE_LABEL += wheezy+gnome+flash:debian-7-x64-gnome
-TEMPLATE_LABEL += jessie:debian-8-x64
-TEMPLATE_LABEL += jessie+flash:debian-8-x64
-TEMPLATE_LABEL += jessie+gnome:debian-8-x64-gnome
-TEMPLATE_LABEL += jessie+gnome+flash:debian-8-x64-gnome
-TEMPLATE_LABEL += trusty:qubuntu-trusty-x64
-TEMPLATE_LABEL += trusty+flash:qubuntu-trusty-x64
-TEMPLATE_LABEL += trusty+desktop:qubuntu-trusty-x64-desktop
-TEMPLATE_LABEL += trusty+desktop+flash:qubuntu-trusty-x64-desktop
-TEMPLATE_LABEL += utopic:qubuntu-utopic-x64
-TEMPLATE_LABEL += utopic+flash:qubuntu-utopic-x64
-TEMPLATE_LABEL += utopic+desktop:qubuntu-utopic-x64-desktop
-TEMPLATE_LABEL += utopic+desktop+flash:qubuntu-utopic-x64-desktop
-TEMPLATE_LABEL += vivid:qubuntu-vivid-x64
-TEMPLATE_LABEL += vivid+flash:qubuntu-vivid-x64
-TEMPLATE_LABEL += vivid+desktop:qubuntu-vivid-x64-desktop
-TEMPLATE_LABEL += vivid+desktop+flash:qubuntu-vivid-x64-desktop
-TEMPLATE_LABEL += wheezy+whonix-gateway:whonix-gateway-experimental
-TEMPLATE_LABEL += wheezy+whonix-workstation:whonix-workstation-experimental
-TEMPLATE_LABEL += wheezy+whonix-workstation+flash:whonix-workstation-experimental
-TEMPLATE_LABEL += wheezy+whonix-workstation+gnome:whonix-workstation-gnome
-TEMPLATE_LABEL += wheezy+whonix-workstation+gnome+flash:whonix-workstation-gnome
+TEMPLATE_LABEL += wheezy+whonix-gateway+standard:whonix-gw-experimental
+TEMPLATE_LABEL += wheezy+whonix-gateway+minimal:whonix-gw-experimental-minimal
+TEMPLATE_LABEL += wheezy+whonix-workstation+standard:whonix-ws
+TEMPLATE_LABEL += wheezy+whonix-workstation+gnome+standard:whonix-ws-gnome
 
 # Location of templates flavors that are not in default location. 
 # Example: wheezy+whonix-gateway would normally be in 

--- a/example-configs/whonix.conf
+++ b/example-configs/whonix.conf
@@ -19,17 +19,15 @@ RELEASE := 3
 
 # GIT_PREFIX - Git release repo prefix
 # Default: R2: qubes-r2/  R3: qubes-r3/
-GIT_PREFIX := marmarek/qubes-
+GIT_PREFIX := QubesOS/qubes-
 
 # DISTS_VM - Choose the templates to build.  Multiple templates can be defined 
 # to build.  Uncomment tempalte dist to build.
 # Default: fc20
 DISTS_VM := 
-DISTS_VM += wheezy+whonix-gateway
-#DISTS_VM += wheezy+whonix-workstation
-#DISTS_VM += wheezy+whonix-workstation+flash
-#DISTS_VM += wheezy+whonix-workstation+gnome
-#DISTS_VM += wheezy+whonix-workstation+gnome+flash
+DISTS_VM += whonix-gateway
+#DISTS_VM += whonix-workstation
+#DISTS_VM += whonix-workstation+gnome
 
 # DEBUG - Print verbose messages about qubes-builder itself - set "1" to use it
 # Default: no value

--- a/setup
+++ b/setup
@@ -343,10 +343,23 @@ chooseDistsDialog() {
 writeConfiguration() {
     dists=($@)
 
+    # Enable all the selected DISTS_VMs
+    #--------------------------------------------------------------------------
     echo "DISTS_VM :=" > ${CONF_FILE}
     for dist in ${dists[@]}; do
         echo "DISTS_VM += ${dist}" >> "${CONF_FILE}"
     done
+    
+    # Set 'DISTS_DEFINED ?= 1' to allow aliases to function.  The setup.conf
+    # configuration file is not loaded during setup which prevent this value
+    # from being set during the setup process and therefore allows the
+    # reading of all the default DISTS_VMs to be able to provide in the
+    # chooseDistsDialog.  Setup clears this value when running.
+    #--------------------------------------------------------------------------
+    if [ -e "${CONF_OVERRIDE}" ]; then
+        comment 'DISTS_DEFINED enables the alias parsing functions when set.'
+        echo -e "DISTS_DEFINED ?= 1" >> "${CONF_FILE}"
+    fi
 }
 
 
@@ -370,7 +383,7 @@ summary() {
     comment "Qubes Release: ${RELEASE}" \
         "Source Prefix: ${GIT_PREFIX} (repo)" "" \
             "Master Configuration File(s):" "setup.conf ${about}" "" \
-            "builder.conf linked to:" "${CONF_MASTER_DIR}/${CONF_MASTER_FILE}"
+            "builder.conf linked to:" "${CONF_MASTER_DIR}/${CONF_MASTER_FILE}."
 
     # Set SSH mode on/off; will translate git@ to https:// if disabled
     #--------------------------------------------------------------------------
@@ -391,7 +404,7 @@ summary() {
     # Disable some COMPONENTS if template only build
     #--------------------------------------------------------------------------
     if [ "${TEMPLATE}" == "1" ]; then
-        comment "Only build templates (comment out to build all of Qubes)"
+        comment "Only build templates (comment out to build all of Qubes)."
         echo -e "TEMPLATE_ONLY ?= ${TEMPLATE}" >> "${CONF_FILE}"
     fi
 
@@ -403,7 +416,7 @@ about::
 	@echo "setup.conf"
 EOF
 
-    info "New configuration file written to: ${CONF_FILE}"
+    info "New configuration file written to: ${CONF_FILE}."
     debug "$(cat ${CONF_FILE})"
     info
 }
@@ -411,6 +424,7 @@ EOF
 
 instructions() {
     # Qubes build info
+    #--------------------------------------------------------------------------
     if [ "${TEMPLATE}" != "1" ]; then
         read -r -d '' BUILD_QUBES <<'EOF' || true
 Complete Qubes Build Steps
@@ -425,6 +439,7 @@ EOF
     fi
 
     # Template build info
+    #--------------------------------------------------------------------------
     read -r -d '' BUILD_TEMPLATES <<'EOF' || true
 Template Only Build Steps
 -------------------------
@@ -492,7 +507,7 @@ function parseMakefiles {
     # Move setup.conf out of the way if it exists 
     #--------------------------------------------------------------------------
     if [ -f "${CONF_FILE}" ]; then
-        SELECTED_DISTS_VM=( $(GET_VAR=DISTS_VM make get-var) )
+        SELECTED_DISTS_VM=( $(DISTS_DEFINED= GET_VAR=DISTS_VM make get-var) )
         mv "${CONF_FILE}" "${CONF_FILE_OLD}"
     fi
 


### PR DESCRIPTION
linux-template-builder and builder-debian packages contain depends on these commits

- Aliases can be set as the DISTS_VM which will map to a pre-existing alias which can
  contain additional template flavors /options.  The template will automatically be
  named after the alias name if no pre-existing TEMPLATE_NAME configuration exists.

- Debian packaging was changed a bit to allow a minimal template flavor and is used
  as the base install.  A regular Debian install will add the additional +standard
  template flavours which in turn will install the standard packages lists as well
  as the minimal ones.

- An addition template flavor (+no-recommends) has also been created which can be used
  currently with any Debian based template to prevent installing additional
  no-recommends packages.

- TEMPLATE_NAMES were also trimmed down to a minimum and now unused TEMPLATES_NAMES
  are removed from the array to speed up processing when building the template.

- Removed all +flash template flavors from setup configuration template since they
  provide warnings about being outdated in the browser.  The flavor still remains
  in the repo for anyone who still wished to utilize it.

- Added the build-info target to get-sources as well to be able to very quickly
  visualize what the overall configuration details look like.

