### PR TITLE
flavor plugin. Allows flavors to use config file from its own seperate package

### DIFF
--- a/example-configs/extended-rules.conf
+++ b/example-configs/extended-rules.conf
@@ -29,6 +29,13 @@ TEMPLATE_FLAVOR := $(shell echo $(TEMPLATE_FLAVOR))
 WHONIX_DIR := $(shell echo $(WHONIX_DIR))
 DEPENDENCIES := $(shell echo $(DEPENDENCIES))
 
+# Plugin and include 'active' flavor configurations if they exist
+dist_split = $(subst +, ,$(DIST))
+dist = $(word 1,$(dist_split))
+flavors = $(filter-out $(dist), $(dist_split))
+FLAVORS := $(sort $(strip $(foreach DIST, $(DISTS_VM), $(flavors))))
+$(foreach FLAVOR, $(FLAVORS), $(eval -include $(SRC_DIR)/$(FLAVOR)/$(FLAVOR).conf))
+
 # Add / Remove Whonix components based on if Whonix is being built
 ifneq (,$(findstring wheezy+whonix, $(DISTS_VM)))
   WHONIX := 1
@@ -95,7 +102,7 @@ build-info::
 	@echo "GIT_REPOS       = $(GIT_REPOS)"
 	@echo "COMPONENTS      = $(COMPONENTS)"
 	@echo "TEMPLATE_LABEL  = $(TEMPLATE_LABEL)"
-	@echo
+	@echo "FLAVORS         = $(FLAVORS)"
 
 .PHONY: get-sources
 get-sources:: COMPONENTS := $(filter-out builder $(BUILDER_PLUGINS), $(COMPONENTS))


### PR DESCRIPTION
Created a flavor plugin that will load its configuration from its package if active

Flavor also uses its own package directory for any template scripts.

Example:
  +app-salt-config will load its configuration from
  qubes-src/app-salt-config/app-salt-config.conf, if available.  The config may
  contain directives for linux-template-builder to load any flavor template
  scripts from the package directory

See qubes-salt-config for a working example