### PR TITLE
Update the template.conf for archlinux template

### DIFF
--- a/example-configs/templates.conf
+++ b/example-configs/templates.conf
@@ -211,6 +211,7 @@ ifeq "$(SETUP_MODE)" "1"
   DISTS_VM += utopic+desktop
   DISTS_VM += vivid
   DISTS_VM += vivid+desktop
+  DISTS_VM += archlinux
 endif
 
 ################################################################################


### PR DESCRIPTION
Added line to the DIST of VMs section to include archlinux to the list

'DIST_VM += archlinux

This prevents the need for a override.conf file when using the ./setup script to list the archlinux choice in  the choose templates section of the script.
